### PR TITLE
Add exponent to theorem of optimal soft-policy

### DIFF
--- a/src/6.ContinuousControl/6.2.SAC.tex
+++ b/src/6.ContinuousControl/6.2.SAC.tex
@@ -329,7 +329,7 @@ $$
 \end{theorem}
 
 \begin{proposition}
-Если $\pi(a \mid s) \propto Q^{\pi}_{\soft}(s, a)$, то она оптимальна.
+Если $\pi(a \mid s) \propto \exp Q^{\pi}_{\soft}(s, a)$, то она оптимальна.
 \begin{proof}
 Q-функция такой стратегии удовлетворяет мягкому уравнению оптимальности Беллмана \eqref{softQ*Q*} и в силу единственности его решения совпадает с $Q^*_{\soft}(s, a)$.
 \end{proof}


### PR DESCRIPTION
Seems that exp is missing
![image](https://user-images.githubusercontent.com/9883873/149316786-bd54a3df-5a28-4adc-863d-b96eb84f8720.png)
